### PR TITLE
Add hci_ctrl_o and remove hwpe_sel_o in cluster_control_unit

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -1,6 +1,9 @@
 package:
   name: cluster_peripherals
 
+dependencies:
+  hci: { git: "https://github.com/pulp-platform/hci.git", version: "1.0" }
+
 sources:
   - cluster_control_unit/cluster_control_unit.sv
 

--- a/cluster_control_unit/cluster_control_unit.sv
+++ b/cluster_control_unit/cluster_control_unit.sv
@@ -58,9 +58,9 @@
 // 0x88:         TCDM arbitration configuration CH1 (DMA HWCE)
 ////////////////////////////////////////////////////////////////////////////////
 
-import hci_package::*;
 
 module cluster_control_unit
+import hci_package::*;
 #(
     parameter NB_CORES      = 4,
     parameter PER_ID_WIDTH  = 5,

--- a/src_files.yml
+++ b/src_files.yml
@@ -1,4 +1,9 @@
 cluster_control_unit:
+  vlog_opts: [
+    +nowarnSVCHK,
+    -suppress 2275,
+    -L hci_lib,
+  ]
   files: [
     cluster_control_unit/cluster_control_unit.sv,
   ]


### PR DESCRIPTION
Small change in the cluster control unit preliminary for the integration of HCI in the PULP cluster. The `hwpe_sel_o` signal being removed has not been used since Fulmine.