### PR TITLE
Add HWPE static selection signal

### DIFF
--- a/cluster_control_unit/cluster_control_unit.sv
+++ b/cluster_control_unit/cluster_control_unit.sv
@@ -63,10 +63,12 @@
 module cluster_control_unit
 import hci_package::*;
 #(
-    parameter NB_CORES      = 4,
-    parameter PER_ID_WIDTH  = 5,
-    parameter ROM_BOOT_ADDR = 32'h1A000000,
-    parameter BOOT_ADDR     = 32'h1C000000
+    parameter NB_CORES       = 4,
+    parameter PER_ID_WIDTH   = 5,
+    parameter ROM_BOOT_ADDR  = 32'h1A000000,
+    parameter BOOT_ADDR      = 32'h1C000000,
+    parameter NB_HWPES       = 8,
+    localparam HWPE_SEL_BITS = $clog2(NB_HWPES)
 )
 (
     input logic                       clk_i,
@@ -81,7 +83,7 @@ import hci_package::*;
     output logic                      cluster_cg_en_o,
 
     output logic                      hwpe_en_o,
-    output logic                      hwpe_sel_o,
+    output logic [HWPE_SEL_BITS-1:0]  hwpe_sel_o,
     output hci_interconnect_ctrl_t    hci_ctrl_o,
 
     output logic                      fregfile_disable_o,
@@ -111,7 +113,7 @@ import hci_package::*;
   logic                               event_n;
 
   logic                               hwpe_en_n;
-  logic                               hwpe_sel_n;
+  logic [HWPE_SEL_BITS-1:0]           hwpe_sel_n;
   logic [10:0]                        hci_ctrl_n, hci_ctrl_q;
 
   logic                               fregfile_disable_n;
@@ -202,10 +204,10 @@ import hci_package::*;
           end
 
           3'b011:
-          //      +------------------------------------------------------------+
-          // ADDR |   unused    | hwpe_sel | fregfile_dis | hwpe_en | hci_ctrl |
-          // 0x18 |   31..14    |    13    |      12      |   11    |  10..0   |
-          //      +------------------------------------------------------------+
+          //      +---------------------------------------------------------------------------------+
+          // ADDR |        unused        |       hwpe_sel       | fregfile_dis | hwpe_en | hci_ctrl |
+          // 0x18 | 31..13+HWPE_SEL_BITS | 12+HWPE_SEL_BITS..13 |      12      |   11    |  10..0   |
+          //      +---------------------------------------------------------------------------------+
           begin
             rdata_n[OFFSET_2+OFFSET_1+1]          = 0;
             rdata_n[OFFSET_2+OFFSET_1  ]          = 0;
@@ -214,7 +216,7 @@ import hci_package::*;
             rdata_n[OFFSET_2+OFFSET_1+2:0]        = hci_ctrl_q;
             rdata_n[OFFSET_2+OFFSET_1+3]          = hwpe_en_o;
             rdata_n[OFFSET_2+OFFSET_1+4]          = fregfile_disable_o;
-            rdata_n[OFFSET_2+OFFSET_1+5]          = hwpe_sel_o;
+            rdata_n[OFFSET_2+OFFSET_1+5+:HWPE_SEL_BITS] = hwpe_sel_o;
           end
 
           3'b100: rdata_n[0] = cluster_cg_en_o;
@@ -299,7 +301,7 @@ import hci_package::*;
             hci_ctrl_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+2:0];
             hwpe_en_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+3];
             fregfile_disable_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+4];
-            hwpe_sel_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+5];
+            hwpe_sel_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+5+:HWPE_SEL_BITS];
           end
           3'b100: begin
             cluster_cg_en_n = speriph_slave.wdata[0];

--- a/cluster_control_unit/cluster_control_unit.sv
+++ b/cluster_control_unit/cluster_control_unit.sv
@@ -81,6 +81,7 @@ import hci_package::*;
     output logic                      cluster_cg_en_o,
 
     output logic                      hwpe_en_o,
+    output logic                      hwpe_sel_o,
     output hci_interconnect_ctrl_t    hci_ctrl_o,
 
     output logic                      fregfile_disable_o,
@@ -110,6 +111,7 @@ import hci_package::*;
   logic                               event_n;
 
   logic                               hwpe_en_n;
+  logic                               hwpe_sel_n;
   logic [10:0]                        hci_ctrl_n, hci_ctrl_q;
 
   logic                               fregfile_disable_n;
@@ -200,10 +202,10 @@ import hci_package::*;
           end
 
           3'b011:
-          //      +------------------------------------------------+
-          // ADDR |   unused   | fregfile_dis | hwpe_en | hci_ctrl |
-          // 0x18 |   31..13   |      12      |   11    |  10..0   |
-          //      +------------------------------------------------+
+          //      +------------------------------------------------------------+
+          // ADDR |   unused    | hwpe_sel | fregfile_dis | hwpe_en | hci_ctrl |
+          // 0x18 |   31..14    |    13    |      12      |   11    |  10..0   |
+          //      +------------------------------------------------------------+
           begin
             rdata_n[OFFSET_2+OFFSET_1+1]          = 0;
             rdata_n[OFFSET_2+OFFSET_1  ]          = 0;
@@ -212,6 +214,7 @@ import hci_package::*;
             rdata_n[OFFSET_2+OFFSET_1+2:0]        = hci_ctrl_q;
             rdata_n[OFFSET_2+OFFSET_1+3]          = hwpe_en_o;
             rdata_n[OFFSET_2+OFFSET_1+4]          = fregfile_disable_o;
+            rdata_n[OFFSET_2+OFFSET_1+5]          = hwpe_sel_o;
           end
 
           3'b100: rdata_n[0] = cluster_cg_en_o;
@@ -254,6 +257,7 @@ import hci_package::*;
   always_comb
   begin
     hwpe_en_n   = hwpe_en_o;
+    hwpe_sel_n  = hwpe_sel_o;
     hci_ctrl_n  = hci_ctrl_q;
 
     fregfile_disable_n = fregfile_disable_o;
@@ -295,6 +299,7 @@ import hci_package::*;
             hci_ctrl_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+2:0];
             hwpe_en_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+3];
             fregfile_disable_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+4];
+            hwpe_sel_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+5];
           end
           3'b100: begin
             cluster_cg_en_n = speriph_slave.wdata[0];
@@ -336,8 +341,9 @@ import hci_package::*;
       rdata_q           <= '0;
       id_q              <= '0;
       rvalid_q          <= 1'b0;
-       
+
       hwpe_en_o         <= 1'b0;
+      hwpe_sel_o        <= 1'b0;
       hci_ctrl_q        <= '0;
 
       fregfile_disable_o<= 1'b0;
@@ -365,8 +371,9 @@ import hci_package::*;
         rdata_q <= rdata_n;
         id_q    <= id_n;
       end
-      
+
       hwpe_en_o         <= hwpe_en_n;
+      hwpe_sel_o        <= hwpe_sel_n;
       hci_ctrl_q        <= hci_ctrl_n;
 
       fregfile_disable_o<= fregfile_disable_n;


### PR DESCRIPTION
Add a single bit as HWPE selection signal in a similar manner to `hwpe_en`. We must decide whether we want a parametric number of HWPEs to select from, but this would make the field mapping in the register variable.