### PR TITLE
[IDMA CLOCK GATING] Changes to control iDMA wrapper clock from cluster control unit

### DIFF
--- a/cluster_control_unit/cluster_control_unit.sv
+++ b/cluster_control_unit/cluster_control_unit.sv
@@ -86,6 +86,8 @@ import hci_package::*;
     output logic [HWPE_SEL_BITS-1:0]  hwpe_sel_o,
     output hci_interconnect_ctrl_t    hci_ctrl_o,
 
+    output logic                      idma_en_o,
+
     output logic                      fregfile_disable_o,
 
     input  logic [NB_CORES-1:0]       core_halted_i,  // cores are in halted mode (which means debugging)
@@ -115,6 +117,8 @@ import hci_package::*;
   logic                               hwpe_en_n;
   logic [HWPE_SEL_BITS-1:0]           hwpe_sel_n;
   logic [10:0]                        hci_ctrl_n, hci_ctrl_q;
+
+  logic                               idma_en_n;
 
   logic                               fregfile_disable_n;
 
@@ -207,17 +211,18 @@ import hci_package::*;
           3'b011:
           //      +---------------------------------------------------------------------------------+
           // ADDR |        unused        |       hwpe_sel       | fregfile_dis | hwpe_en | hci_ctrl |
-          // 0x18 | 31..13+HWPE_SEL_BITS | 12+HWPE_SEL_BITS..13 |      12      |   11    |  10..0   |
+          // 0x18 | 31..15+HWPE_SEL_BITS | 12+HWPE_SEL_BITS..13 |      12      |   11    |  10..0   |
           //      +---------------------------------------------------------------------------------+
           begin
-            rdata_n[OFFSET_2+OFFSET_1+1]          = 0;
-            rdata_n[OFFSET_2+OFFSET_1  ]          = 0;
-            rdata_n[OFFSET_2+OFFSET_1-1:OFFSET_1] = 0;
-            rdata_n[OFFSET_1-1:0]                 = 0;
-            rdata_n[OFFSET_2+OFFSET_1+2:0]        = hci_ctrl_q;
-            rdata_n[OFFSET_2+OFFSET_1+3]          = hwpe_en_o;
-            rdata_n[OFFSET_2+OFFSET_1+4]          = fregfile_disable_o;
+            rdata_n[OFFSET_2+OFFSET_1+1]                = 0;
+            rdata_n[OFFSET_2+OFFSET_1  ]                = 0;
+            rdata_n[OFFSET_2+OFFSET_1-1:OFFSET_1]       = 0;
+            rdata_n[OFFSET_1-1:0]                       = 0;
+            rdata_n[OFFSET_2+OFFSET_1+2:0]              = hci_ctrl_q;
+            rdata_n[OFFSET_2+OFFSET_1+3]                = hwpe_en_o;
+            rdata_n[OFFSET_2+OFFSET_1+4]                = fregfile_disable_o;
             rdata_n[OFFSET_2+OFFSET_1+5+:HWPE_SEL_BITS] = hwpe_sel_o;
+            rdata_n[OFFSET_2+OFFSET_1+6+HWPE_SEL_BITS]  = idma_en_o;
           end
 
           3'b100: rdata_n[0] = cluster_cg_en_o;
@@ -263,6 +268,8 @@ import hci_package::*;
     hwpe_sel_n  = hwpe_sel_o;
     hci_ctrl_n  = hci_ctrl_q;
 
+    idma_en_n = idma_en_o;
+
     fregfile_disable_n = fregfile_disable_o;
 
     fetch_en_n  = fetch_en_q;
@@ -303,6 +310,7 @@ import hci_package::*;
             hwpe_en_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+3];
             fregfile_disable_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+4];
             hwpe_sel_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+5+:HWPE_SEL_BITS];
+            idma_en_n = speriph_slave.wdata[OFFSET_2+OFFSET_1+6+HWPE_SEL_BITS];
           end
           3'b100: begin
             cluster_cg_en_n = speriph_slave.wdata[0];
@@ -347,6 +355,9 @@ import hci_package::*;
 
       hwpe_en_o         <= 1'b0;
       hwpe_sel_o        <= 1'b0;
+
+      idma_en_o      <= 1'b1;
+
       hci_ctrl_q        <= '0;
 
       fregfile_disable_o<= 1'b0;
@@ -378,6 +389,8 @@ import hci_package::*;
       hwpe_en_o         <= hwpe_en_n;
       hwpe_sel_o        <= hwpe_sel_n;
       hci_ctrl_q        <= hci_ctrl_n;
+
+      idma_en_o      <= idma_en_n;
 
       fregfile_disable_o<= fregfile_disable_n;
 


### PR DESCRIPTION
* [iDMA CLOCK GATING] Changes to enable total iDMA clock gating from cluster control unit

* [IDMA CLOCK GATING] Fix on signal names

* [IDMA CLOCK GATING] Enable iDMA sw-controlled clock by default

Related to this PR: https://github.com/pulp-platform/pulp_cluster/pull/115